### PR TITLE
Fix path for phantomjs binary

### DIFF
--- a/script/html2pdf.sh
+++ b/script/html2pdf.sh
@@ -18,7 +18,7 @@ fi
 
 INPUT=$1
 OUTPUT=$2
-PHANTOMJS=$4
+PHANTOMJS=$DIR/$4
 
 [ -z $PHANTOMJS ] && PHANTOMJS="phantomjs"
 


### PR DESCRIPTION
Hi,
I have an installation of current Thruk v2.0.6 and have found an error when launching/creating a new Report. It raises this error:

![seleccion_215](https://cloud.githubusercontent.com/assets/1044532/14605279/35dab566-0578-11e6-8258-941f7bd82e42.png)

<pre>
 /usr/share/thruk/script/html2pdf.sh: line 28: phantomjs: command not found 

NOTE: line 36 in my script debt to logging to the log file
</pre>


I have logged the 4 variables arriving at the script (_html2pdf.sh_)

<pre>
/var/lib/thruk/reports/1.html
/var/lib/thruk/reports/1.dat.pdf
/var/lib/thruk/reports/1.log
phantomjs
</pre>


If **phantomjs** is not in the "current PATH" the scripts fail and raises the above reported error. Just specifying the full path, the script and the report finishes correctly.
